### PR TITLE
[Help wanted] Convert to GDExtension.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "godot-cpp"]
+	path = godot-cpp
+	url = https://github.com/godotengine/godot-cpp.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "godot-cpp"]
 	path = godot-cpp
-	url = https://github.com/godotengine/godot-cpp.git
+	url = https://github.com/Faless/godot-cpp.git

--- a/SConstruct
+++ b/SConstruct
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+import os
+import sys
+
+env = SConscript("godot-cpp/SConstruct")
+
+# For the reference:
+# - CCFLAGS are compilation flags shared between C and C++
+# - CFLAGS are for C-specific compilation flags
+# - CXXFLAGS are for C++-specific compilation flags
+# - CPPFLAGS are for pre-processor flags
+# - CPPDEFINES are for pre-processor defines
+# - LINKFLAGS are for linking flags
+
+# tweak this if you want to use different folders, or more folders, to store your source code in.
+env.Append(CPPPATH=["."])
+env.Append(CPPDEFINES=["GDEXTENSION"])
+sources = Glob("./*.cpp")
+
+if env["platform"] == "osx":
+    library = env.SharedLibrary(
+        "bin/libgdvisualscript.{}.{}.framework/libgdvisualscript.{}.{}".format(
+            env["platform"], env["target"], env["platform"], env["target"]
+        ),
+        source=sources,
+    )
+else:
+    library = env.SharedLibrary(
+        "bin/libgdvisualscript.{}.{}.{}{}".format(
+            env["platform"], env["target"], env["arch_suffix"], env["SHLIBSUFFIX"]
+        ),
+        source=sources,
+    )
+
+Default(library)

--- a/register_types.cpp
+++ b/register_types.cpp
@@ -30,8 +30,19 @@
 
 #include "register_types.h"
 
+#ifdef GDEXTENSION
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/godot.hpp>
+
+using namespace godot;
+
+#else
+#include "modules/register_module_types.h"
 #include "core/config/engine.h"
 #include "core/io/resource_loader.h"
+#endif
+
 #include "visual_script.h"
 #include "visual_script_builtin_funcs.h"
 #include "visual_script_expression.h"
@@ -148,3 +159,19 @@ void uninitialize_visual_script_module(ModuleInitializationLevel p_level) {
 	}
 #endif
 }
+#ifdef GDEXTENSION
+extern "C" {
+
+// Initialization.
+
+GDNativeBool GDN_EXPORT example_library_init(const GDNativeInterface *p_interface, const GDNativeExtensionClassLibraryPtr p_library, GDNativeInitialization *r_initialization) {
+        godot::GDExtensionBinding::InitObject init_obj(p_interface, p_library, r_initialization);
+
+        init_obj.register_initializer(initialize_visual_script_module);
+        init_obj.register_terminator(uninitialize_visual_script_module);
+        init_obj.set_minimum_library_initialization_level(MODULE_INITIALIZATION_LEVEL_SCENE);
+
+        return init_obj.init();
+}
+}
+#endif

--- a/register_types.h
+++ b/register_types.h
@@ -31,7 +31,16 @@
 #ifndef VISUAL_SCRIPT_REGISTER_TYPES_H
 #define VISUAL_SCRIPT_REGISTER_TYPES_H
 
+#ifdef GDEXTENSION
+#include <godot/gdnative_interface.h>
+#include <godot_cpp/godot.hpp>
+#define ModuleInitializationLevel GDNativeInitializationLevel
+using namespace godot;
+
+#else
 #include "modules/register_module_types.h"
+
+#endif
 
 void initialize_visual_script_module(ModuleInitializationLevel p_level);
 void uninitialize_visual_script_module(ModuleInitializationLevel p_level);

--- a/visual_script.cpp
+++ b/visual_script.cpp
@@ -30,10 +30,18 @@
 
 #include "visual_script.h"
 
+#ifdef GDEXTENSION
+#include <godot_cpp/classes/node.hpp>
+#include <godot_cpp/classes/os.hpp>
+#include <godot_cpp/classes/project_settings.hpp>
+#else
+
 #include "core/config/project_settings.h"
 #include "core/core_string_names.h"
 #include "core/os/os.h"
 #include "scene/main/node.h"
+#endif
+
 #include "visual_script_nodes.h"
 
 // Used by editor, this is not really saved.
@@ -1783,15 +1791,19 @@ void VisualScriptInstance::notification(int p_notification) {
 }
 
 String VisualScriptInstance::to_string(bool *r_valid) {
-	if (has_method(CoreStringNames::get_singleton()->_to_string)) {
+	static StringName sname;
+	if (sname.is_empty()) {
+		sname = StringName("_to_string");
+	}
+	if (has_method(sname)) {
 		Callable::CallError ce;
-		Variant ret = callp(CoreStringNames::get_singleton()->_to_string, nullptr, 0, ce);
+		Variant ret = callp(sname, nullptr, 0, ce);
 		if (ce.error == Callable::CallError::CALL_OK) {
 			if (ret.get_type() != Variant::STRING) {
 				if (r_valid) {
 					*r_valid = false;
 				}
-				ERR_FAIL_V_MSG(String(), "Wrong type for " + CoreStringNames::get_singleton()->_to_string + ", must be a String.");
+				ERR_FAIL_V_MSG(String(), "Wrong type for " + sname + ", must be a String.");
 			}
 			if (r_valid) {
 				*r_valid = true;

--- a/visual_script.h
+++ b/visual_script.h
@@ -36,6 +36,7 @@
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/script_language_extension.hpp>
 
 #include <godot_cpp/templates/hash_map.hpp>
 #include <godot_cpp/templates/list.hpp>
@@ -46,6 +47,14 @@
 using namespace godot;
 
 #define RES_BASE_EXTENSION(ext)
+
+// TODO This will need more work than just this.
+#define ScriptLanguage ScriptLanguageExtension
+
+// TODO ScriptInstance (via C struct: GDNativeExtensionScriptInstanceInfo, see gdnative_interface.h).
+class ScriptInstance {
+
+};
 
 #else
 #include "core/debugger/engine_debugger.h"
@@ -172,6 +181,7 @@ public:
 
 	virtual int get_working_memory_size() const { return 0; }
 
+	// TODO What to do with Callable::CallError ? Add to godot-cpp? Does it make sense? Is it exposed to extensions?
 	virtual int step(const Variant **p_inputs, Variant **p_outputs, StartMode p_start_mode, Variant *p_working_mem, Callable::CallError &r_error, String &r_error_str) = 0; // Do a step, return which sequence port to go out.
 
 	Ref<VisualScriptNode> get_base_node() { return Ref<VisualScriptNode>(base); }

--- a/visual_script.h
+++ b/visual_script.h
@@ -36,9 +36,16 @@
 #include <godot_cpp/core/defs.hpp>
 #include <godot_cpp/godot.hpp>
 #include <godot_cpp/classes/script.hpp>
-#include <godot_cpp/classes/script_instance_extension.hpp>
+
+#include <godot_cpp/templates/hash_map.hpp>
+#include <godot_cpp/templates/list.hpp>
+#include <godot_cpp/templates/rb_set.hpp>
+#include <godot_cpp/templates/rb_set.hpp>
+#include <godot_cpp/templates/vector.hpp>
 
 using namespace godot;
+
+#define RES_BASE_EXTENSION(ext)
 
 #else
 #include "core/debugger/engine_debugger.h"
@@ -75,7 +82,7 @@ protected:
 public:
 	Ref<VisualScript> get_visual_script() const;
 
-	virtual int get_output_sequence_port_count() const {}
+	virtual int get_output_sequence_port_count() const { return 0; }
 	virtual bool has_input_sequence_port() const { return false; }
 
 	virtual String get_output_sequence_port_text(int p_port) const { return ""; }

--- a/visual_script.h
+++ b/visual_script.h
@@ -31,12 +31,23 @@
 #ifndef VISUAL_SCRIPT_H
 #define VISUAL_SCRIPT_H
 
+#ifdef GDEXTENSION
+#include <godot_cpp/core/class_db.hpp>
+#include <godot_cpp/core/defs.hpp>
+#include <godot_cpp/godot.hpp>
+#include <godot_cpp/classes/script.hpp>
+#include <godot_cpp/classes/script_instance_extension.hpp>
+
+using namespace godot;
+
+#else
 #include "core/debugger/engine_debugger.h"
 #include "core/debugger/script_debugger.h"
 #include "core/doc_data.h"
 #include "core/object/script_language.h"
 #include "core/os/thread.h"
 #include "core/templates/rb_set.h"
+#endif
 
 class VisualScriptInstance;
 class VisualScriptNodeInstance;
@@ -64,31 +75,31 @@ protected:
 public:
 	Ref<VisualScript> get_visual_script() const;
 
-	virtual int get_output_sequence_port_count() const = 0;
-	virtual bool has_input_sequence_port() const = 0;
+	virtual int get_output_sequence_port_count() const {}
+	virtual bool has_input_sequence_port() const { return false; }
 
-	virtual String get_output_sequence_port_text(int p_port) const = 0;
+	virtual String get_output_sequence_port_text(int p_port) const { return ""; }
 
 	virtual bool has_mixed_input_and_sequence_ports() const { return false; }
 
-	virtual int get_input_value_port_count() const = 0;
-	virtual int get_output_value_port_count() const = 0;
+	virtual int get_input_value_port_count() const { return 0; }
+	virtual int get_output_value_port_count() const { return 0; }
 
-	virtual PropertyInfo get_input_value_port_info(int p_idx) const = 0;
-	virtual PropertyInfo get_output_value_port_info(int p_idx) const = 0;
+	virtual PropertyInfo get_input_value_port_info(int p_idx) const { return PropertyInfo(); }
+	virtual PropertyInfo get_output_value_port_info(int p_idx) const { return PropertyInfo(); }
 
 	void set_default_input_value(int p_port, const Variant &p_value);
 	Variant get_default_input_value(int p_port) const;
 
-	virtual String get_caption() const = 0;
+	virtual String get_caption() const { return ""; }
 	virtual String get_text() const;
-	virtual String get_category() const = 0;
+	virtual String get_category() const { return ""; }
 
 	// Used by editor, this is not really saved.
 	void set_breakpoint(bool p_breakpoint);
 	bool is_breakpoint() const;
 
-	virtual VisualScriptNodeInstance *instantiate(VisualScriptInstance *p_instance) = 0;
+	virtual VisualScriptNodeInstance *instantiate(VisualScriptInstance *p_instance) { return nullptr; }
 
 	struct TypeGuess {
 		Variant::Type type = Variant::NIL;

--- a/visual_script_builtin_funcs.h
+++ b/visual_script_builtin_funcs.h
@@ -146,7 +146,12 @@ public:
 	VisualScriptBuiltinFunc();
 };
 
+#ifdef GDEXTENSION
+VARIANT_ENUM_CAST(VisualScriptBuiltinFunc, BuiltinFunc);
+
+#else
 VARIANT_ENUM_CAST(VisualScriptBuiltinFunc::BuiltinFunc)
+#endif
 
 void register_visual_script_builtin_func_node();
 

--- a/visual_script_func_nodes.h
+++ b/visual_script_func_nodes.h
@@ -132,9 +132,6 @@ public:
 	VisualScriptFunctionCall();
 };
 
-VARIANT_ENUM_CAST(VisualScriptFunctionCall::CallMode);
-VARIANT_ENUM_CAST(VisualScriptFunctionCall::RPCCallMode);
-
 class VisualScriptPropertySet : public VisualScriptNode {
 	GDCLASS(VisualScriptPropertySet, VisualScriptNode);
 
@@ -237,9 +234,6 @@ public:
 	VisualScriptPropertySet();
 };
 
-VARIANT_ENUM_CAST(VisualScriptPropertySet::CallMode);
-VARIANT_ENUM_CAST(VisualScriptPropertySet::AssignOp);
-
 class VisualScriptPropertyGet : public VisualScriptNode {
 	GDCLASS(VisualScriptPropertyGet, VisualScriptNode);
 
@@ -321,8 +315,6 @@ public:
 	VisualScriptPropertyGet();
 };
 
-VARIANT_ENUM_CAST(VisualScriptPropertyGet::CallMode);
-
 class VisualScriptEmitSignal : public VisualScriptNode {
 	GDCLASS(VisualScriptEmitSignal, VisualScriptNode);
 
@@ -359,5 +351,21 @@ public:
 };
 
 void register_visual_script_func_nodes();
+
+#ifdef GDEXTENSION
+VARIANT_ENUM_CAST(VisualScriptFunctionCall, CallMode);
+VARIANT_ENUM_CAST(VisualScriptFunctionCall, RPCCallMode);
+VARIANT_ENUM_CAST(VisualScriptPropertySet, CallMode);
+VARIANT_ENUM_CAST(VisualScriptPropertySet, AssignOp);
+VARIANT_ENUM_CAST(VisualScriptPropertyGet, CallMode);
+
+#else
+VARIANT_ENUM_CAST(VisualScriptFunctionCall::CallMode);
+VARIANT_ENUM_CAST(VisualScriptFunctionCall::RPCCallMode);
+VARIANT_ENUM_CAST(VisualScriptPropertySet::CallMode);
+VARIANT_ENUM_CAST(VisualScriptPropertySet::AssignOp);
+VARIANT_ENUM_CAST(VisualScriptPropertyGet::CallMode);
+
+#endif
 
 #endif // VISUAL_SCRIPT_FUNC_NODES_H

--- a/visual_script_nodes.h
+++ b/visual_script_nodes.h
@@ -31,9 +31,16 @@
 #ifndef VISUAL_SCRIPT_NODES_H
 #define VISUAL_SCRIPT_NODES_H
 
+#ifdef GDEXTENSION
+#include <godot/gdnative_interface.h>
+using namespace godot;
+
+#else
 #include "core/object/gdvirtual.gen.inc"
 #include "core/object/script_language.h"
 #include "scene/main/multiplayer_api.h"
+#endif
+
 #include "visual_script.h"
 
 class VisualScriptFunction : public VisualScriptNode {
@@ -590,8 +597,6 @@ public:
 	VisualScriptMathConstant();
 };
 
-VARIANT_ENUM_CAST(VisualScriptMathConstant::MathConstant)
-
 class VisualScriptEngineSingleton : public VisualScriptNode {
 	GDCLASS(VisualScriptEngineSingleton, VisualScriptNode);
 
@@ -820,8 +825,6 @@ public:
 	VisualScriptCustomNode();
 };
 
-VARIANT_ENUM_CAST(VisualScriptCustomNode::StartMode);
-
 class VisualScriptSubCall : public VisualScriptNode {
 	GDCLASS(VisualScriptSubCall, VisualScriptNode);
 
@@ -1040,8 +1043,6 @@ public:
 	VisualScriptInputAction();
 };
 
-VARIANT_ENUM_CAST(VisualScriptInputAction::Mode)
-
 class VisualScriptDeconstruct : public VisualScriptNode {
 	GDCLASS(VisualScriptDeconstruct, VisualScriptNode);
 
@@ -1088,5 +1089,17 @@ public:
 
 void register_visual_script_nodes();
 void unregister_visual_script_nodes();
+
+#ifdef GDEXTENSION
+VARIANT_ENUM_CAST(VisualScriptInputAction, Mode);
+VARIANT_ENUM_CAST(VisualScriptMathConstant, MathConstant);
+VARIANT_ENUM_CAST(VisualScriptCustomNode, StartMode);
+
+#else
+VARIANT_ENUM_CAST(VisualScriptInputAction::Mode);
+VARIANT_ENUM_CAST(VisualScriptMathConstant::MathConstant);
+VARIANT_ENUM_CAST(VisualScriptCustomNode::StartMode);
+
+#endif
 
 #endif // VISUAL_SCRIPT_NODES_H

--- a/visual_script_yield_nodes.h
+++ b/visual_script_yield_nodes.h
@@ -80,7 +80,6 @@ public:
 
 	VisualScriptYield();
 };
-VARIANT_ENUM_CAST(VisualScriptYield::YieldMode)
 
 class VisualScriptYieldSignal : public VisualScriptNode {
 	GDCLASS(VisualScriptYieldSignal, VisualScriptNode);
@@ -140,8 +139,17 @@ public:
 	VisualScriptYieldSignal();
 };
 
+void register_visual_script_yield_nodes();
+
+#ifdef GDEXTENSION
+VARIANT_ENUM_CAST(VisualScriptYield, YieldMode)
+VARIANT_ENUM_CAST(VisualScriptYieldSignal, CallMode);
+
+
+#else
+VARIANT_ENUM_CAST(VisualScriptYield::YieldMode)
 VARIANT_ENUM_CAST(VisualScriptYieldSignal::CallMode);
 
-void register_visual_script_yield_nodes();
+#endif
 
 #endif // VISUAL_SCRIPT_YIELD_NODES_H


### PR DESCRIPTION
Some minimal initial work to start the project of converting the module to a GDExtension.

The PR does not yet properly compile, but the build system is there, you can try by just typing `scons`.

The godot-cpp submodule uses this branch: https://github.com/godotengine/godot-cpp/pull/819 .

Bare minimum things to implement:
- "`ScriptInstanceExtension`" via a `GDNativeExtensionScriptInstanceInfo` wrapper.
- `ScriptLanguageExtension` methods name (prefix with `_`?).
- ...

see (https://github.com/godotengine/godot-visual-script/commit/741f1315f782a1c213d998ad8396ac513399bdd7).

I sadly don't have time to work on this right now, but I hope this PR can at least open a path to external contributions.