### PR TITLE
Fix compilation errors for Godot 4.2

### DIFF
--- a/visual_script.cpp
+++ b/visual_script.cpp
@@ -873,6 +873,10 @@ bool VisualScript::is_valid() const {
 	return true; // Always valid.
 }
 
+bool VisualScript::is_abstract() const {
+	return false;
+}
+
 ScriptLanguage *VisualScript::get_language() const {
 	return VisualScriptLanguage::singleton;
 }
@@ -2430,6 +2434,9 @@ bool VisualScriptLanguage::is_control_flow_keyword(String p_keyword) const {
 }
 
 void VisualScriptLanguage::get_comment_delimiters(
+		List<String> *p_delimiters) const {}
+
+void VisualScriptLanguage::get_doc_comment_delimiters(
 		List<String> *p_delimiters) const {}
 
 void VisualScriptLanguage::get_string_delimiters(

--- a/visual_script.h
+++ b/visual_script.h
@@ -380,6 +380,7 @@ public:
 
 	virtual bool is_tool() const override;
 	virtual bool is_valid() const override;
+	virtual bool is_abstract() const override;
 
 	virtual ScriptLanguage *get_language() const override;
 
@@ -636,6 +637,8 @@ public:
 	virtual bool is_control_flow_keyword(String p_keyword) const override;
 	virtual void
 	get_comment_delimiters(List<String> *p_delimiters) const override;
+	virtual void
+	get_doc_comment_delimiters(List<String> *p_delimiters) const override;
 	virtual void get_string_delimiters(List<String> *p_delimiters) const override;
 	virtual bool is_using_templates() override;
 	virtual Ref<Script>


### PR DESCRIPTION
Implements the missing abstract functions to allow the module to be compiled for Godot 4.2.